### PR TITLE
fix(docs): update team portfolio links for Lim Zerui

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -2,7 +2,7 @@
 
 Display |   Name    |            Github Profile             | Portfolio 
 --------|:---------:|:-------------------------------------:|:---------:
-![](https://via.placeholder.com/100.png?text=Photo) | Lim Zerui | [Github](https://github.com/limzerui) | [Portfolio](docs/team/johndoe.md)
+![](https://via.placeholder.com/100.png?text=Photo) | Lim Zerui | [Github](https://github.com/limzerui) | [Portfolio](docs/team/Zerui.md)
 ![](https://via.placeholder.com/100.png?text=Photo) |  Don Joe  |     [Github](https://github.com/)     | [Portfolio](docs/team/johndoe.md)
 ![](https://via.placeholder.com/100.png?text=Photo) | Ron John  |     [Github](https://github.com/)     | [Portfolio](docs/team/johndoe.md)
 ![](https://via.placeholder.com/100.png?text=Photo) | John Roe  |     [Github](https://github.com/)     | [Portfolio](docs/team/johndoe.md)


### PR DESCRIPTION
- Corrected portfolio link from `docs/team/johndoe.md` to `docs/team/Zerui.md`
- Ensured GitHub profile and portfolio references are accurate